### PR TITLE
Fixed incompatibility with Apache 2.4.

### DIFF
--- a/lib/Foswiki/Engine/Apache.pm
+++ b/lib/Foswiki/Engine/Apache.pm
@@ -95,7 +95,11 @@ sub run {
 sub prepareConnection {
     my ( $this, $req ) = @_;
     $req->method( $this->{r}->method );
-    $req->remoteAddress( $this->{r}->connection->remote_ip );
+    $req->remoteAddress(
+        $this->{r}->connection->can('remote_ip') ?
+        $this->{r}->connection->remote_ip :
+        $this->{r}->connection->client_ip
+    );
     if ( $INC{'Apache2/ModSSL.pm'} ) {
         $req->secure( $this->{r}->connection->is_https ? 1 : 0 );
     }


### PR DESCRIPTION
In Apache 2.4 they removed the remote_ip field (see [this doc](https://httpd.apache.org/docs/2.4/developer/new_api_2_4.html)). This patch enables compatibility with new and old versions.
